### PR TITLE
Context Attributes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,13 +30,18 @@ When a URI is not supplied a scan is performed and all found contexts are used t
 
 ### Hardware maps
 
-pytest-libiio allows tests to be filtered based on markers with specific hardware maps. These maps are essentially a list of IIO device names which make up a specific platform or board. These are defined in a yaml file which will have contents similar to the one below:
+pytest-libiio allows tests to be filtered based on markers with specific hardware maps. These maps are essentially a list of IIO device names and attributes which make up or identify a specific platform or board. These are defined in a yaml file which will have contents similar to the one below:
 
 ``` yaml
 pluto:
   - adm1177
   - ad9361-phy
   - cf-ad9361-lpc,2
+pluto_rev_c:
+  - ad9361-phy
+  - cf-ad9361-lpc,2
+  - ctx_attr:
+    - hw_model: Analog Devices PlutoSDR Rev.C
 fmcomms5:
   - ad9361-phy
   - ad9361-phy-b
@@ -48,6 +53,8 @@ These are arranged in the form:
 <platform name>:
   - <driver 1>,<number of channels of driver 1 (optional)>
   - <driver 2>,<number of channels of driver 2 (optional)>
+  - ctx_attr:
+    - <context attribute name>: <value>
 ...
 ```
 

--- a/pytest_libiio/resources/adi_hardware_map.yml
+++ b/pytest_libiio/resources/adi_hardware_map.yml
@@ -15,6 +15,11 @@ pluto:
   - adm1177
   - ad9361-phy
   - cf-ad9361-lpc,2
+pluto_rev_c:
+  - ad9361-phy
+  - cf-ad9361-lpc,2
+  - ctx_attr:
+    - hw_model: Analog Devices PlutoSDR Rev.C
 daq2:
   - axi-ad9144-hpc,4
   - axi-ad9680-hpc,2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ def pytest_addoption(parser):
         "--disable_mock", action="store_true", help="Disable mocking",
     )
     parser.addoption(
-        "--hw",
+        "--hw-manual",
         action="store",
         dest="hw_map",
         default=None,
@@ -30,7 +30,7 @@ def use_mocking(request):
 
 @pytest.fixture(scope="session")
 def hw_select(request):
-    val = request.config.getoption("--hw")
+    val = request.config.getoption("--hw-manual")
     if not val:
         return "adrv9361"
     else:


### PR DESCRIPTION
PR allows specification of context attributes in hardware lookup map. The main use case here is for Pluto but as context attribute add more information this can be helpful for identifying boards.

An input parameter to override found hardware was added as well. This is handy for debugging without having to specify a custom map file.