### PR TITLE
Handle case when uri not in context attributes

### DIFF
--- a/pytest_libiio/plugin.py
+++ b/pytest_libiio/plugin.py
@@ -140,10 +140,14 @@ def _contexts(request):
         devices = ",".join(devices)
 
         hw = request.config.getoption("--hw") or lookup_hw_from_map(ctx, map)
+        if "uri" in ctx.attrs:
+            uri_type = ctx.attrs["uri"].split(":")[0]
+        else:
+            uri_type = uri.split(":")[0]
 
         ctx_plus_hw = {
             "uri": uri,
-            "type": ctx.attrs["uri"].split(":")[0],
+            "type": uri_type,
             "devices": devices,
             "hw": hw,
         }


### PR DESCRIPTION
For older builds and some systems, the URI is not always available in
the context attributes. The handles this case and defaults to using
passed uri to determine context type.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>