### PR TITLE
pytest_libiio/plugin.py: Changed adi_hw_map's default to True

### DIFF
--- a/pytest_libiio/plugin.py
+++ b/pytest_libiio/plugin.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser):
         "--adi-hw-map",
         action="store_true",
         dest="adi_hw_map",
-        default=False,
+        default=True,
         help="Use ADI hardware map to determine hardware names based on context drivers",
     )
     group.addoption(


### PR DESCRIPTION
# Description

Changed adi_hw_map's default to True to lessen instances of unintentionally skipping tests while running pytest.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Signed-off-by: Hannah Rosete <hannah.rosete@analog.com>