### PR TITLE
Add support for ADRV9002 RX2TX2

### DIFF
--- a/pytest_libiio/resources/adi_hardware_map.yml
+++ b/pytest_libiio/resources/adi_hardware_map.yml
@@ -55,6 +55,17 @@ ad9364:
   - cf-ad9361-lpc,2
 adrv9002:
   - adrv9002-phy
+  - axi-adrv9002-rx-lpc
+  - axi-adrv9002-rx2-lpc
+  - axi-adrv9002-core-tdd1-lpc
+  - axi-adrv9002-core-tdd2-lpc
+  - axi-adrv9002-tx-lpc
+  - axi-adrv9002-tx2-lpc
+adrv9002-rx2tx2:
+  - adrv9002-phy
+  - axi-adrv9002-rx-lpc
+  - axi-adrv9002-core-tdd-lpc
+  - axi-adrv9002-tx-lpc
 adrv9009:
   - adrv9009-phy
 adrv9009-dual:


### PR DESCRIPTION
# Description

Adding support for ADRV9002's rx2tx2 configuration. As you can see on the code comparison below, it might seem that have interchanged "adrv9002" to that of "adrv9002-rx2tx2"'s list of IIO devices. To explain, here is an image of the list of IIO devices in ADRV9002-ZCU102 loaded with a Independent, CMOS devicetree:

![image](https://user-images.githubusercontent.com/43806793/123192524-b4b7d080-d4d5-11eb-8c66-ef8eab70d276.png)

The Independent mode has RX2 and TX2 on its list of IIO devices, but doesn't have "rx2tx2" on its devicetree's (Linux) name. On the other hand, MIMO doesn't have RX2 and TX2 on its IIO devices list, but have "rx2tx2" on its devicetree's filename.

Thus, "adrv9002" on the adi_hardware_map.yaml refers to the Independent mode, while "adrv9002-rx2tx2" refers to the MIMO mode. I consulted with the team and we decided to follow the naming convention of the Linux devicetree for less confusion on the JSL's and Nebula's side.

Wiki Link: https://wiki.analog.com/resources/tools-software/linux-drivers/iio-transceiver/adrv9002


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have signed off all commits and they contain "Signed-off by: <insert name>"
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


Signed-off-by: Hannah Rosete <hannah.rosete@analog.com>