### PR TITLE
adi_hardware_map: update pluto driver name adm1177 to adm1177-iio

### DIFF
--- a/pytest_libiio/resources/adi_hardware_map.yml
+++ b/pytest_libiio/resources/adi_hardware_map.yml
@@ -13,7 +13,7 @@ fmcomms5:
   - cf-ad9361-A,8
   - cf-ad9361-B,4
 pluto:
-  - adm1177
+  - adm1177-iio
   - ad9361-phy
   - cf-ad9361-lpc,2
   - emulate:


### PR DESCRIPTION
change device name because of update caused by firmware v0.34