### PR TITLE
Add xdist support

### DIFF
--- a/.github/scripts/install_iioemu.sh
+++ b/.github/scripts/install_iioemu.sh
@@ -10,7 +10,7 @@ sudo make install
 sudo ldconfig
 cd ../..
 
-git clone -b v0.1.0 https://github.com/analogdevicesinc/iio-emu.git
+git clone -b main https://github.com/analogdevicesinc/iio-emu.git
 cd iio-emu
 mkdir build && cd build
 cmake ..

--- a/pytest_libiio/plugin.py
+++ b/pytest_libiio/plugin.py
@@ -237,6 +237,8 @@ def pytest_collection_modifyitems(config, items):
     request = Object()
     request.config = config
     pytest._context_table = find_contexts(config, get_hw_map(request), request)
+    if not pytest._context_table:
+        return
 
     # Add xdist marker to split tests based on context
     for item in items:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ pyyaml
 coveralls
 tox
 paramiko
+pytest-xdist

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,14 @@ setup(
     packages=["pytest_libiio"],
     package_data={"pytest_libiio": ["resources/*"]},
     python_requires=">=3.5",
-    install_requires=["pytest>=3.5.0", "pylibiio>=0.23.1", "pyyaml", "lxml", "click"],
+    install_requires=[
+        "pytest>=3.5.0",
+        "pylibiio>=0.23.1",
+        "pyyaml",
+        "lxml",
+        "click",
+        "pytest-xdist",
+    ],
     extras_require={"ssh": ["paramiko"]},
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_xdist_support.py
+++ b/tests/test_xdist_support.py
@@ -1,0 +1,34 @@
+"""Tests for verifying plugin works with pytest-xdist."""
+
+import pytest
+import iio
+import logging
+
+# Create file logger
+# logger = logging.getLogger(__name__)
+# logger.setLevel(logging.INFO)
+# fh = logging.FileHandler('/tmp/test_xdist_support.log')
+# fh.setLevel(logging.INFO)
+# logger.addHandler(fh)
+
+@pytest.mark.iio_hardware('fmcomms2')
+def test_fmcomms2_xdist(iio_uri):
+    print(f"iio_uri: {iio_uri}")
+    logging.info(f"iio_uri: {iio_uri}")
+
+
+    ctx = iio.Context(iio_uri)
+    for dev in ctx.devices:
+        print(f"dev: {dev.name}, {dev.id}")
+        logging.info(f"dev: {dev.name}, {dev.id}")
+
+
+@pytest.mark.iio_hardware('ad9081')
+def test_ad9081_xdist(iio_uri):
+    print(f"iio_uri: {iio_uri}")
+    logging.info(f"iio_uri: {iio_uri}")
+
+    ctx = iio.Context(iio_uri)
+    for dev in ctx.devices:
+        print(f"dev: {dev.name}, {dev.id}")
+        logging.info(f"dev: {dev.name}, {dev.id}")

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     pyyaml
     pytest-mock
     pytest-cov
+    pytest-xdist
     paramiko
 commands = pytest {posargs:tests} --cov-config=.coveragerc --cov={envsitepackagesdir}/pytest_libiio --cov-append --cov-report=term-missing --resource-dir={toxinidir}/tests/resources
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for pytest-xdist to enable parallel test execution by introducing custom port handling and xdist markers. Update the iio_emu_manager class and logging configuration to accommodate these changes. Include pytest-xdist as a dependency and update the iio-emu installation script. Add tests to verify the new functionality.

New Features:
- Introduce support for pytest-xdist to enable parallel test execution by adding custom port handling and xdist markers.

Enhancements:
- Modify the iio_emu_manager class to support custom port configuration for parallel test execution.
- Update logging configuration to create separate log files for each xdist worker.

Build:
- Add pytest-xdist to the list of install requirements in setup.py.
- Update the iio-emu installation script to clone the main branch instead of a specific version.

Tests:
- Add new tests in tests/test_xdist_support.py to verify the plugin's compatibility with pytest-xdist.

<!-- Generated by sourcery-ai[bot]: end summary -->