### PR TITLE
Upcoming change: rename xml_gen to iio-emu_gen_xml

### DIFF
--- a/docs/emulation.md
+++ b/docs/emulation.md
@@ -9,10 +9,10 @@ To use device emulation you will need [libtinyiiod](https://github.com/analogdev
 
 ## Adding device support
 
-Emulating hardware is done through a XML file generated from an existing hardware set up and pointing the tool [xml_gen](https://github.com/analogdevicesinc/iio-emu/blob/master/GENERIC_EMULATOR.md) or [gen-xml](cli_tools.md) to the target context:
+Emulating hardware is done through a XML file generated from an existing hardware set up and pointing the tool [iio-emu_gen_xml](https://github.com/analogdevicesinc/iio-emu/blob/master/GENERIC_EMULATOR.md) or [gen-xml](cli_tools.md) to the target context:
 
 ```bash
-xml_gen ip:pluto.local > pluto.xml
+iio-emu_gen_xml ip:pluto.local > pluto.xml
 ```
 
 This XML file can be manually used with **pytest-libiio** by leveraging the *--emu-xml* flag as so:


### PR DESCRIPTION
xml_gen will likely be renamed to iio-emu_gen_xml on the next release.

https://github.com/analogdevicesinc/iio-emu/commit/cbc0c0419767a30321b627581fbe6f62f1ce4e80

## Summary by Sourcery

Documentation:
- Update documentation to reflect the renaming of the xml_gen tool to iio-emu_gen_xml.