### PR TITLE
Fix doc logo duplication

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@ extensions = [
 html_theme = "furo"
 
 html_static_path = ["_static"]
-html_logo = "_static/logo-pytest-libiio.svg"
 html_favicon = "_static/favicon-pytest-libiio.svg"
 html_theme_options = {
     "light_logo": "logo-pytest-libiio.svg",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove redundant html_logo setting to prevent duplicate logo rendering in the generated documentation.