### PR TITLE
docs: document device-level attribute coverage

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,16 +82,22 @@ For a worked example see [Scenario: telemetry capture](fixtures.md#scenario-tele
 
 ## Coverage tracking
 
-When **--iio-coverage** is set, pytest-libiio monkey-patches `iio.ChannelAttr`
-to record every attribute read and write performed by your tests, grouped by
-the matched hardware context. The `iio_uri` fixture installs the per-context
-tracker automatically — no per-test plumbing is required.
+When **--iio-coverage** is set, pytest-libiio monkey-patches both
+`iio.ChannelAttr` and `iio.DeviceAttr` to record every attribute read and write
+performed by your tests, grouped by the matched hardware context. Both
+device-level attributes and per-channel attributes are tracked by default. The
+`iio_uri` fixture installs the per-context tracker automatically — no per-test
+plumbing is required.
 
 After the session finishes the plugin writes:
 
-- One `<hw>_coverage.json` file per context with the raw per-attribute counts.
+- One `<hw>_coverage.json` file per context with the raw per-attribute counts,
+  split into `device_attr_reads_writes` and `channel_attr_reads_writes`
+  sections (plus `debug_attr_reads_writes` when **--iio-coverage-debug-props**
+  is set).
 - One `iio_coverage_report.md` aggregating coverage percentages across all
-  contexts.
+  contexts, with a row per system for `device_coverage`, `channel_coverage`,
+  and `total_coverage`.
 
 Both land in the directory named by **--iio-coverage-folder** (default
 `iio_coverage_results`). Pass **--iio-coverage-print-results** to also dump the

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -162,17 +162,22 @@ See [Emulation](emulation.md) for details on adding new device XML files.
 When `--iio-coverage` is passed, `iio_uri` activates a per-context
 [attribute coverage tracker](https://github.com/tfcollins/pytest-libiio/blob/main/pytest_libiio/coverage.py)
 that records every IIO attribute read or written during the test session via a
-monkey-patch on `iio.ChannelAttr`. No change to your test code is required.
+monkey-patch on both `iio.ChannelAttr` and `iio.DeviceAttr`. Device-level and
+per-channel attributes are tracked by default and no change to your test code is
+required.
 
 ```bash
 pytest --emu --adi-hw-map --iio-coverage --iio-coverage-folder=cov_out
 ```
 
 After the session finishes the plugin writes one `<hw>_coverage.json` file per
-context plus an aggregated `iio_coverage_report.md` into the coverage folder
-(default `iio_coverage_results/`). Pass `--iio-coverage-print-results` to also
-dump the per-context attribute map to stdout, or `--iio-coverage-debug-props`
-to track debug attributes too.
+context — with separate `device_attr_reads_writes` and
+`channel_attr_reads_writes` sections — plus an aggregated
+`iio_coverage_report.md` that reports `device_coverage`, `channel_coverage`, and
+`total_coverage` per system, into the coverage folder (default
+`iio_coverage_results/`). Pass `--iio-coverage-print-results` to also dump the
+per-context attribute map to stdout, or `--iio-coverage-debug-props` to track
+debug attributes too.
 
 ---
 


### PR DESCRIPTION
## Summary

The device-property coverage work in `4ef1c66` extended IIO coverage tracking to monkey-patch `iio.DeviceAttr` in addition to `iio.ChannelAttr`, but the documentation was never updated to reflect it. The `cli.md` and `fixtures.md` coverage sections still described the feature as channel-only.

This was the only documentation gap found after auditing all CLI options (15/15 documented), fixtures, markers, emulation, and CLI tools against the source — everything else is already documented end-to-end.

## Changes

- **`docs/cli.md`** — Coverage tracking section now states both `iio.ChannelAttr` and `iio.DeviceAttr` are patched, device + channel attributes are tracked by default, and describes the JSON (`device_attr_reads_writes` / `channel_attr_reads_writes`) and markdown report rows (`device_coverage`, `channel_coverage`, `total_coverage`).
- **`docs/fixtures.md`** — *Scenario: attribute coverage* updated to match.

## Verification

- `nox -s docs` builds clean with `-W -n` (warnings-as-errors, nitpicky) — no warnings.
- Docs-only change; no code touched.

## Summary by Sourcery

Document device- and channel-level IIO attribute coverage behavior in the CLI and fixtures documentation.

Documentation:
- Update CLI coverage tracking docs to explain tracking of both device and channel attributes and the structure of JSON and markdown coverage reports.
- Update fixtures documentation scenario to describe device-level coverage, attribute sections in the JSON output, and coverage metrics in the aggregated report.