### PR TITLE
feat: add coverage blacklist for devices, channels, and attributes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,8 @@ When the flag **--adi-hw-map** is used the provided map from [plugin itself is u
 
 If the flag **--hw=<hardware name>** is used the hardware map is ignored and the provided URI is defined as that hardware. This is handy if you do not want to create a custom map or are debugging. Note that **--hw** is only applicable when **--uri** is also used.
 
+A hardware entry may also carry a `blacklist:` section used to exclude specific devices, channels, or attributes from **--iio-coverage** tracking. See [Blacklisting devices, channels, and attributes](#blacklisting-devices-channels-and-attributes).
+
 ## Telemetry
 
 When the flag **--telm** is used, hardware telemetry is collected on each test. This enables a fixture that is autouse, meaning it is automatically used by all tests. The telemetry is collected in a folder defined by **--telm-data-folder=<path\>**. The folder is created if it does not exist. Telemetry data is stored in individual files that are specific to a URI. So after a test suite run there should one file for every hardware platform under test. The test files are generated at pickle files and contain different metadata. This is primarily just IIO based information. However, if the optional SSH dependency is installed, additional metadata is collected from the target hardware if it uses an IP context.
@@ -103,5 +105,48 @@ Both land in the directory named by **--iio-coverage-folder** (default
 `iio_coverage_results`). Pass **--iio-coverage-print-results** to also dump the
 per-context attribute map to stdout, or **--iio-coverage-debug-props** to
 include debug attributes in the tally.
+
+### Blacklisting devices, channels, and attributes
+
+Some attributes are noise for coverage purposes — diagnostic devices, write-only
+or unsupported attributes, or whole families no test could reasonably exercise.
+These drag down the reported percentage without adding signal. To exclude them,
+add a `blacklist:` section to the relevant hardware entry in the
+[hardware map](#hardware-maps) (works with both **--adi-hw-map** and
+**--custom-hw-map**). Blacklisted items are removed entirely: they are not
+counted when accessed and do not appear in the coverage denominator.
+
+``` yaml
+pluto:
+  - ad9361-phy
+  - cf-ad9361-lpc,2
+  - emulate:
+      - filename: pluto.xml
+  - blacklist:
+      devices:                                   # whole devices (all channels/attrs)
+        - xadc
+        - "cf-*"                                  # glob: every capture device
+      channels:                                  # whole channels (all their attrs)
+        - {device: ad9361-phy, id: voltage0}
+        - {device: ad9361-phy, id: "voltage*", direction: output}
+      attributes:
+        - {device: ad9361-phy, name: calib_mode_available}        # device-level attr
+        - {device: ad9361-phy, channel: voltage0, name: hardwaregain}  # channel attr
+        - {device: "*", channel: "*", name: raw}                  # raw on every channel
+```
+
+- **devices** — a list of device-name patterns. A match removes the device and
+  everything under it.
+- **channels** — a list of mappings with `device` and `id` (both required) and
+  an optional `direction` (`input` or `output`). A match removes the channel and
+  all its attributes.
+- **attributes** — a list of mappings with `device` and `name` (both required).
+  Omit `channel` for a device-level attribute; include `channel` (and optional
+  `direction`) for a channel attribute.
+
+Every string field is matched as a case-sensitive glob (Python's
+`fnmatch.fnmatchcase`), so `*` and `?` wildcards are supported, and an omitted
+optional field matches anything. Debug attributes (**--iio-coverage-debug-props**)
+honor whole-`devices` blacklisting only.
 
 For a worked example see [Scenario: attribute coverage](fixtures.md#scenario-attribute-coverage).

--- a/pytest_libiio/coverage.py
+++ b/pytest_libiio/coverage.py
@@ -1,10 +1,91 @@
 """Coverage tracking for iio attributes using monkey patching."""
 
+import fnmatch
 import json
 import os
 from pprint import pprint
 
 import iio
+
+
+def _match(pattern, value):
+    """Case-sensitive glob match. A ``None`` pattern matches anything."""
+    if pattern is None:
+        return True
+    return fnmatch.fnmatchcase(value, pattern)
+
+
+class Blacklist:
+    """Match devices, channels, and attributes to exclude from coverage.
+
+    Built from a per-hardware ``blacklist`` mapping in the hardware map YAML::
+
+        blacklist:
+          devices: [xadc, "cf-*"]
+          channels:
+            - {device: ad9361-phy, id: voltage0}
+          attributes:
+            - {device: ad9361-phy, name: in_temp0_input}
+            - {device: ad9361-phy, channel: voltage0, name: hardwaregain}
+
+    All string fields are matched as case-sensitive globs
+    (:func:`fnmatch.fnmatchcase`). Missing optional fields match anything.
+    """
+
+    def __init__(self, spec):
+        spec = spec or {}
+        self._devices = list(spec.get("devices") or [])
+        self._channels = list(spec.get("channels") or [])
+        self._attributes = list(spec.get("attributes") or [])
+
+    def device_blacklisted(self, device):
+        """True if the whole device is excluded."""
+        return any(_match(pat, device) for pat in self._devices)
+
+    def channel_blacklisted(self, device, channel, direction):
+        """True if the whole channel (and all its attrs) is excluded."""
+        if self.device_blacklisted(device):
+            return True
+        for entry in self._channels:
+            if (
+                _match(entry.get("device"), device)
+                and _match(entry.get("id"), channel)
+                and _match(entry.get("direction"), direction)
+            ):
+                return True
+        return False
+
+    def attr_blacklisted(self, device, channel, attr, direction):
+        """True if a single attribute is excluded.
+
+        ``channel`` is ``None`` for device-level attributes; otherwise the
+        attribute belongs to the named channel.
+        """
+        if channel is None:
+            if self.device_blacklisted(device):
+                return True
+            for entry in self._attributes:
+                if "channel" in entry:
+                    continue
+                if _match(entry.get("device"), device) and _match(
+                    entry.get("name"), attr
+                ):
+                    return True
+            return False
+
+        if self.channel_blacklisted(device, channel, direction):
+            return True
+        for entry in self._attributes:
+            if "channel" not in entry:
+                continue
+            if (
+                _match(entry.get("device"), device)
+                and _match(entry.get("channel"), channel)
+                and _match(entry.get("name"), attr)
+                and _match(entry.get("direction"), direction)
+            ):
+                return True
+        return False
 
 
 class MultiContextTracker:
@@ -15,6 +96,9 @@ class MultiContextTracker:
         self.track_context_props = False
         self.track_debug_props = False
         self.results_folder = "iio_coverage_results"
+        # Per-hardware blacklist specs, keyed by hardware name. Populated from
+        # the hardware map; consulted in add_instance.
+        self.blacklists = {}
 
     def do_monkey_patch(self):
         """Apply monkey patch to iio.py."""
@@ -32,7 +116,11 @@ class MultiContextTracker:
         """
         if name not in self.trackers:
             self.trackers[name] = CoverageTracker(
-                name, uri, self.track_context_props, self.track_debug_props
+                name,
+                uri,
+                self.track_context_props,
+                self.track_debug_props,
+                blacklist=self.blacklists.get(name),
             )
         else:
             raise Exception(f"{name} already in tracker list")
@@ -56,6 +144,7 @@ class CoverageTracker:
         track_context_props=False,
         track_debug_props=False,
         results_folder=None,
+        blacklist=None,
     ):
         self.name = name
         self.context_attr_reads_writes = {}
@@ -67,6 +156,7 @@ class CoverageTracker:
         self.track_context_props = track_context_props
         self.track_debug_props = track_debug_props
         self.results_folder = results_folder or "iio_coverage_results"
+        self.blacklist = Blacklist(blacklist) if blacklist else None
         self.build_context_map()
 
     def reset(self):
@@ -77,20 +167,38 @@ class CoverageTracker:
         self.debug_attr_reads_writes.clear()
 
     def build_context_map(self):
-        """Build a map of context attributes."""
+        """Build a map of context attributes.
+
+        Entries excluded by ``self.blacklist`` are omitted entirely so they
+        never count toward coverage denominators.
+        """
+        bl = self.blacklist
         if self.track_context_props:
             self.context_attr_reads_writes = {attr: 0 for attr in self.ctx.attrs}
         for dev in self.ctx.devices:
-            self.device_attr_reads_writes[dev.name] = {attr: 0 for attr in dev.attrs}
+            if bl and bl.device_blacklisted(dev.name):
+                continue
+            self.device_attr_reads_writes[dev.name] = {
+                attr: 0
+                for attr in dev.attrs
+                if not (bl and bl.attr_blacklisted(dev.name, None, attr, None))
+            }
             for inout in ["input", "output"]:
                 for channel in dev.channels:
                     inout = "output" if channel.output else "input"
+                    if bl and bl.channel_blacklisted(dev.name, channel.id, inout):
+                        continue
                     if dev.name not in self.channel_attr_reads_writes:
                         self.channel_attr_reads_writes[dev.name] = {}
                     if inout not in self.channel_attr_reads_writes[dev.name]:
                         self.channel_attr_reads_writes[dev.name][inout] = {}
                     self.channel_attr_reads_writes[dev.name][inout][channel.id] = {
-                        attr: 0 for attr in channel.attrs
+                        attr: 0
+                        for attr in channel.attrs
+                        if not (
+                            bl
+                            and bl.attr_blacklisted(dev.name, channel.id, attr, inout)
+                        )
                     }
             if self.track_debug_props:
                 self.debug_attr_reads_writes[dev.name] = {

--- a/pytest_libiio/mkpatch.py
+++ b/pytest_libiio/mkpatch.py
@@ -37,13 +37,18 @@ def _read(self):
         device_name = name_raw.decode("ascii") if name_raw is not None else None
 
     tracker = _get_tracker()
+    bl = getattr(tracker, "blacklist", None)
     if channel_name and device_name:
         inout = "output" if output else "input"
-        tracker.channel_attr_reads_writes[device_name][inout][channel_name][
-            attr_name
-        ] += 1
+        if not (
+            bl and bl.attr_blacklisted(device_name, channel_name, attr_name, inout)
+        ):
+            tracker.channel_attr_reads_writes[device_name][inout][channel_name][
+                attr_name
+            ] += 1
     elif device_name:
-        tracker.device_attr_reads_writes[device_name][attr_name] += 1
+        if not (bl and bl.attr_blacklisted(device_name, None, attr_name, None)):
+            tracker.device_attr_reads_writes[device_name][attr_name] += 1
     else:
         tracker.context_attr_reads_writes[attr_name] += 1
 
@@ -74,13 +79,18 @@ def _write(self, value):
         device_name = name_raw.decode("ascii") if name_raw is not None else None
 
     tracker = _get_tracker()
+    bl = getattr(tracker, "blacklist", None)
     if channel_name and device_name:
         inout = "output" if output else "input"
-        tracker.channel_attr_reads_writes[device_name][inout][channel_name][
-            attr_name
-        ] += 1
+        if not (
+            bl and bl.attr_blacklisted(device_name, channel_name, attr_name, inout)
+        ):
+            tracker.channel_attr_reads_writes[device_name][inout][channel_name][
+                attr_name
+            ] += 1
     elif device_name:
-        tracker.device_attr_reads_writes[device_name][attr_name] += 1
+        if not (bl and bl.attr_blacklisted(device_name, None, attr_name, None)):
+            tracker.device_attr_reads_writes[device_name][attr_name] += 1
     else:
         tracker.context_attr_reads_writes[attr_name] += 1
 

--- a/pytest_libiio/plugin.py
+++ b/pytest_libiio/plugin.py
@@ -132,6 +132,25 @@ def get_filename(map, hw):
     return fn, dd
 
 
+def extract_blacklists(map):
+    """Return ``{hardware_name: blacklist_spec}`` for entries that define one.
+
+    The blacklist is a ``blacklist:`` dict item inside a hardware entry's list,
+    alongside ``emulate:``/``ctx_attr:``. Used to exclude devices, channels, or
+    attributes from ``--iio-coverage`` tracking.
+    """
+    blacklists = {}
+    if not map:
+        return blacklists
+    for hw, items in map.items():
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if isinstance(item, dict) and "blacklist" in item:
+                blacklists[hw] = item["blacklist"]
+    return blacklists
+
+
 def handle_iio_emu(ctx, request, _iio_emu):
     if "hw" in ctx and hasattr(_iio_emu, "auto") and _iio_emu.auto:
         if _iio_emu.current_device != ctx["hw"]:
@@ -319,11 +338,18 @@ def pytest_sessionstart(session):
 
     if session.config.getoption("--iio-coverage"):
         session.config.pytest_libiio = Object()
-        session.config.pytest_libiio.coverage_tracker = MultiContextTracker()
-        session.config.pytest_libiio.coverage_tracker.do_monkey_patch()
-        session.config.pytest_libiio.coverage_tracker.track_debug_props = bool(
+        tracker = MultiContextTracker()
+        session.config.pytest_libiio.coverage_tracker = tracker
+        tracker.do_monkey_patch()
+        tracker.track_debug_props = bool(
             session.config.getoption("--iio-coverage-debug-props")
         )
+        # Load per-hardware coverage blacklists from the hardware map, if one is
+        # in use. get_hw_map only reads config options, so the session stands in
+        # for a request here.
+        hw_map = get_hw_map(session)
+        if hw_map:
+            tracker.blacklists = extract_blacklists(hw_map)
         print("IIO coverage tracking enabled")
     else:
         session.config.pytest_libiio = Object()

--- a/tests/test_coverage_unit.py
+++ b/tests/test_coverage_unit.py
@@ -41,6 +41,214 @@ class FakeContext:
         ]
 
 
+def test_blacklist_empty_spec_matches_nothing():
+    bl = coverage.Blacklist(None)
+    assert not bl.device_blacklisted("dev0")
+    assert not bl.channel_blacklisted("dev0", "voltage0", "input")
+    assert not bl.attr_blacklisted("dev0", None, "dev_a", None)
+    assert not bl.attr_blacklisted("dev0", "voltage0", "scale", "input")
+
+    bl = coverage.Blacklist({})
+    assert not bl.device_blacklisted("dev0")
+
+
+def test_blacklist_device_exact_and_glob():
+    bl = coverage.Blacklist({"devices": ["xadc", "cf-*"]})
+    assert bl.device_blacklisted("xadc")
+    assert bl.device_blacklisted("cf-ad9361-lpc")
+    assert not bl.device_blacklisted("ad9361-phy")
+    # A blacklisted device cascades to its attrs and channels.
+    assert bl.attr_blacklisted("xadc", None, "in_temp0_input", None)
+    assert bl.attr_blacklisted("cf-ad9361-lpc", "voltage0", "scale", "input")
+    assert bl.channel_blacklisted("cf-ad9361-lpc", "voltage0", "input")
+
+
+def test_blacklist_channel_with_and_without_direction():
+    bl = coverage.Blacklist(
+        {
+            "channels": [
+                {"device": "ad9361-phy", "id": "voltage0"},
+                {"device": "ad9361-phy", "id": "voltage*", "direction": "output"},
+            ]
+        }
+    )
+    # No direction in spec -> matches either direction.
+    assert bl.channel_blacklisted("ad9361-phy", "voltage0", "input")
+    assert bl.channel_blacklisted("ad9361-phy", "voltage0", "output")
+    # Direction-qualified glob entry.
+    assert bl.channel_blacklisted("ad9361-phy", "voltage1", "output")
+    assert not bl.channel_blacklisted("ad9361-phy", "voltage1", "input")
+    # Wrong device.
+    assert not bl.channel_blacklisted("cf-ad9361-lpc", "voltage0", "input")
+    # A blacklisted channel cascades to its attrs.
+    assert bl.attr_blacklisted("ad9361-phy", "voltage0", "scale", "input")
+
+
+def test_blacklist_device_level_attribute():
+    bl = coverage.Blacklist(
+        {"attributes": [{"device": "ad9361-phy", "name": "in_temp0_input"}]}
+    )
+    assert bl.attr_blacklisted("ad9361-phy", None, "in_temp0_input", None)
+    assert not bl.attr_blacklisted("ad9361-phy", None, "frequency", None)
+    # A device-level attribute entry (no channel) must not match a channel attr.
+    assert not bl.attr_blacklisted("ad9361-phy", "voltage0", "in_temp0_input", "input")
+
+
+def test_blacklist_channel_attribute_with_direction():
+    bl = coverage.Blacklist(
+        {
+            "attributes": [
+                {
+                    "device": "ad9361-phy",
+                    "channel": "voltage0",
+                    "name": "hardwaregain",
+                    "direction": "output",
+                }
+            ]
+        }
+    )
+    assert bl.attr_blacklisted("ad9361-phy", "voltage0", "hardwaregain", "output")
+    # Wrong direction.
+    assert not bl.attr_blacklisted("ad9361-phy", "voltage0", "hardwaregain", "input")
+    # A channel-attr entry (has channel) must not match a device-level attr.
+    assert not bl.attr_blacklisted("ad9361-phy", None, "hardwaregain", None)
+
+
+def test_blacklist_attribute_globs_everywhere():
+    bl = coverage.Blacklist(
+        {"attributes": [{"device": "*", "channel": "*", "name": "raw"}]}
+    )
+    assert bl.attr_blacklisted("ad9361-phy", "voltage0", "raw", "input")
+    assert bl.attr_blacklisted("cf-ad9361-lpc", "voltage7", "raw", "output")
+    assert not bl.attr_blacklisted("ad9361-phy", "voltage0", "scale", "input")
+
+
+def test_build_context_map_excludes_blacklisted(monkeypatch):
+    monkeypatch.setattr("pytest_libiio.coverage.iio.Context", lambda uri: FakeContext())
+    spec = {
+        "attributes": [
+            {"device": "dev0", "name": "dev_a"},
+            {"device": "dev0", "channel": "ch_out", "name": "ch_b"},
+        ],
+        "channels": [{"device": "dev0", "id": "ch_in"}],
+    }
+    tracker = coverage.CoverageTracker("dut", "ip:1.2.3.4", blacklist=spec)
+
+    # Device-level attr dev_a removed, dev_b kept.
+    assert "dev_a" not in tracker.device_attr_reads_writes["dev0"]
+    assert "dev_b" in tracker.device_attr_reads_writes["dev0"]
+    # Whole input channel removed.
+    assert "ch_in" not in tracker.channel_attr_reads_writes["dev0"].get("input", {})
+    # Output channel kept, but ch_b attr removed and ch_c kept.
+    chout = tracker.channel_attr_reads_writes["dev0"]["output"]["ch_out"]
+    assert "ch_b" not in chout
+    assert "ch_c" in chout
+
+
+def test_build_context_map_excludes_whole_device(monkeypatch):
+    monkeypatch.setattr("pytest_libiio.coverage.iio.Context", lambda uri: FakeContext())
+    tracker = coverage.CoverageTracker(
+        "dut",
+        "ip:1.2.3.4",
+        track_debug_props=True,
+        blacklist={"devices": ["dev0"]},
+    )
+    assert tracker.device_attr_reads_writes == {}
+    assert tracker.channel_attr_reads_writes == {}
+    assert tracker.debug_attr_reads_writes == {}
+
+
+def test_multi_context_tracker_passes_per_hw_blacklist(monkeypatch):
+    monkeypatch.setattr("pytest_libiio.coverage.iio.Context", lambda uri: FakeContext())
+    mct = coverage.MultiContextTracker()
+    mct.blacklists = {"dut": {"devices": ["dev0"]}}
+
+    mct.add_instance("dut", "ip:1.2.3.4")
+    assert mct.trackers["dut"].device_attr_reads_writes == {}
+
+    # A hardware name with no blacklist entry is tracked normally.
+    mct.add_instance("other", "ip:5.6.7.8")
+    assert mct.trackers["other"].device_attr_reads_writes != {}
+
+
+def test_mkpatch_skips_blacklisted_device_attr(monkeypatch):
+    from pytest_libiio import mkpatch
+
+    monkeypatch.setattr("pytest_libiio.coverage.iio.Context", lambda uri: FakeContext())
+    tracker = coverage.CoverageTracker(
+        "dut",
+        "ip:1.2.3.4",
+        blacklist={"attributes": [{"device": "dev0", "name": "dev_a"}]},
+    )
+    mkpatch.set_coverage_tracker(tracker)
+    try:
+        monkeypatch.setattr(mkpatch, "_d_get_name", lambda dev: b"dev0")
+        reads = []
+        monkeypatch.setattr(
+            mkpatch, "_orig_dev_read", lambda self: reads.append(self.name) or "val"
+        )
+
+        class Attr:
+            def __init__(self, name):
+                self.name = name
+                self._device = object()
+
+        # Blacklisted attr: original still runs, but no count is recorded and
+        # the (absent) key is never indexed -> no KeyError.
+        out = mkpatch._read(Attr("dev_a"))
+        assert out == "val"
+        assert "dev_a" not in tracker.device_attr_reads_writes["dev0"]
+
+        # Non-blacklisted attr still increments.
+        mkpatch._read(Attr("dev_b"))
+        assert tracker.device_attr_reads_writes["dev0"]["dev_b"] == 1
+    finally:
+        mkpatch.reset_coverage_tracker()
+
+
+def test_mkpatch_skips_blacklisted_channel_attr(monkeypatch):
+    from pytest_libiio import mkpatch
+
+    monkeypatch.setattr("pytest_libiio.coverage.iio.Context", lambda uri: FakeContext())
+    tracker = coverage.CoverageTracker(
+        "dut",
+        "ip:1.2.3.4",
+        blacklist={
+            "attributes": [{"device": "dev0", "channel": "ch_out", "name": "ch_b"}]
+        },
+    )
+    mkpatch.set_coverage_tracker(tracker)
+    try:
+        monkeypatch.setattr(mkpatch.iio, "_c_get_id", lambda ch: b"ch_out")
+        monkeypatch.setattr(mkpatch.iio, "_c_is_output", lambda ch: True)
+        monkeypatch.setattr(mkpatch.iio, "_channel_get_device", lambda ch: object())
+        monkeypatch.setattr(mkpatch.iio, "_d_get_name", lambda dev: b"dev0")
+        writes = []
+        monkeypatch.setattr(
+            mkpatch, "_orig_chan_write", lambda self, value: writes.append(value)
+        )
+
+        class Attr:
+            def __init__(self, name):
+                self.name = name
+                self._channel = object()
+
+        # Blacklisted channel attr: original still runs, no count, no KeyError.
+        mkpatch._write(Attr("ch_b"), "5")
+        assert writes == ["5"]
+        assert (
+            "ch_b" not in tracker.channel_attr_reads_writes["dev0"]["output"]["ch_out"]
+        )
+
+        # Non-blacklisted channel attr still increments.
+        mkpatch._write(Attr("ch_c"), "6")
+        assert (
+            tracker.channel_attr_reads_writes["dev0"]["output"]["ch_out"]["ch_c"] == 1
+        )
+    finally:
+        mkpatch.reset_coverage_tracker()
+
+
 def test_multi_context_tracker_add_set_and_duplicate(monkeypatch):
     monkeypatch.setattr("pytest_libiio.coverage.iio.Context", lambda uri: FakeContext())
 

--- a/tests/test_mkpatch.py
+++ b/tests/test_mkpatch.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from pprint import pprint
@@ -111,3 +112,75 @@ def test_emulation_with_coverage(testdir, hw):
 
     # make sure that that we get a '0' exit code for the testsuite
     assert result.ret == 0
+
+
+def test_emulation_coverage_blacklist(testdir):
+    """Blacklisted devices/channels/attributes are excluded from coverage."""
+    time.sleep(sleep)
+
+    # Custom hardware map with a per-hardware blacklist section.
+    testdir.makefile(
+        ".yml",
+        custom_map="""
+pluto:
+  - ad9361-phy
+  - cf-ad9361-lpc,2
+  - emulate:
+      - filename: pluto.xml
+      - data_devices:
+          - iio:device2
+          - iio:device3
+  - blacklist:
+      devices:
+        - xadc
+      attributes:
+        - device: ad9361-phy
+          name: calib_mode_available
+        - device: ad9361-phy
+          channel: voltage0
+          name: hardwaregain
+""",
+    )
+
+    testdir.makepyfile(
+        """
+        import pytest
+        import iio
+
+        @pytest.mark.iio_hardware('pluto')
+        def test_sth(iio_uri):
+            assert iio_uri
+            ctx = iio.Context(iio_uri)
+    """
+    )
+
+    result = testdir.runpytest(
+        "--custom-hw-map=custom_map.yml",
+        "--scan-verbose",
+        "-vvv",
+        "-s",
+        "--emu",
+        "--iio-coverage",
+        "--iio-coverage-folder=iio_coverage_results_bl",
+    )
+
+    result.stdout.fnmatch_lines(["*PASSED*"])
+    result.stdout.fnmatch_lines(["*IIO coverage tracking enabled*"])
+    assert result.ret == 0
+
+    cov_file = testdir.tmpdir.join("iio_coverage_results_bl").join(
+        "pluto_coverage.json"
+    )
+    assert cov_file.exists(), "No coverage data file generated"
+    data = json.loads(cov_file.read())
+
+    dev = data["device_attr_reads_writes"]
+    # Whole device blacklisted.
+    assert "xadc" not in dev
+    # Device-level attribute blacklisted, siblings retained.
+    assert "calib_mode_available" not in dev["ad9361-phy"]
+    assert "calib_mode" in dev["ad9361-phy"]
+    # Channel attribute blacklisted, siblings retained.
+    chan = data["channel_attr_reads_writes"]["ad9361-phy"]["input"]["voltage0"]
+    assert "hardwaregain" not in chan
+    assert "gain_control_mode" in chan

--- a/tests/test_plugin_unit.py
+++ b/tests/test_plugin_unit.py
@@ -126,6 +126,23 @@ def test_gen_markdown_table_and_filename_helpers(tmp_path):
     assert plugin.get_filename(hw_map, "pluto") == ("pluto.xml", ["d0"])
 
 
+def test_extract_blacklists():
+    hw_map = {
+        "pluto": [
+            "ad9361-phy",
+            {"emulate": [{"filename": "pluto.xml"}]},
+            {"blacklist": {"devices": ["xadc"]}},
+        ],
+        "fmcomms2": ["ad9361-phy"],
+    }
+    assert plugin.extract_blacklists(hw_map) == {"pluto": {"devices": ["xadc"]}}
+
+
+def test_extract_blacklists_handles_empty_map():
+    assert plugin.extract_blacklists(None) == {}
+    assert plugin.extract_blacklists({}) == {}
+
+
 def test_get_hw_map_variants(monkeypatch, tmp_path):
     path = tmp_path / "map.yml"
     path.write_text("pluto:\n  - ad9361-phy\n")


### PR DESCRIPTION
## Summary

Adds a per-hardware `blacklist:` section to the hardware-map YAML that excludes specific devices, channels, or attributes from `--iio-coverage` tracking. Blacklisted items are removed **entirely** — they are not counted when accessed and do not appear in the coverage denominator — so the reported percentage reflects only what you intend to track.

This works in tandem with the existing device map: the blacklist lives alongside `emulate:`/`ctx_attr:` in each hardware entry and is keyed by the same hardware name the coverage tracker already uses.

## Schema

```yaml
pluto:
  - ad9361-phy
  - cf-ad9361-lpc,2
  - emulate:
      - filename: pluto.xml
  - blacklist:
      devices: [xadc, "cf-*"]                                  # whole devices
      channels:
        - {device: ad9361-phy, id: voltage0}                  # whole channel
        - {device: ad9361-phy, id: "voltage*", direction: output}
      attributes:
        - {device: ad9361-phy, name: calib_mode_available}    # device-level attr
        - {device: ad9361-phy, channel: voltage0, name: hardwaregain}  # channel attr
        - {device: "*", channel: "*", name: raw}              # glob everywhere
```

Every string field is a case-sensitive glob (`fnmatch.fnmatchcase`); omitted optional fields match anything. Debug attributes honor whole-`devices` blacklisting only.

## Changes

- **`coverage.py`** — new `Blacklist` helper (single `attr_blacklisted` source of truth, plus `device_blacklisted`/`channel_blacklisted`); `build_context_map` skips excluded items; `CoverageTracker`/`MultiContextTracker` carry the per-hw spec.
- **`mkpatch.py`** — `_read`/`_write` gate their increments on the blacklist while still calling the original read/write (no `KeyError` on excluded keys).
- **`plugin.py`** — `extract_blacklists(hw_map)` helper; `pytest_sessionstart` loads it via `get_hw_map(session)`.
- **`docs/cli.md`** — documents the schema, glob support, and the debug-attr limitation.

## Testing

Built with TDD. New tests cover `Blacklist` matching (globs/direction/cascade), `build_context_map` exclusion, tracker wiring, `mkpatch` increment gating, `extract_blacklists`, and an end-to-end emulation test asserting blacklisted keys are absent from `pluto_coverage.json` while siblings remain.

- Full suite: 86 passed, 6 skipped (the 6 are hardware-only smoke tests)
- `ruff check`, `ruff format --check`, and `mypy pytest_libiio` all clean

https://claude.ai/code/session_01XmLzEBjfG32VnfgUswwxSP

## Summary by Sourcery

Add support for per-hardware blacklists that exclude specified devices, channels, and attributes from iio coverage tracking and wire this into the coverage tracker, plugin hardware map handling, and mkpatch counters.

New Features:
- Introduce a configurable blacklist schema for devices, channels, and attributes in hardware map entries to control what is included in iio coverage.
- Support per-hardware coverage blacklists in MultiContextTracker and CoverageTracker so excluded items are omitted from coverage maps and denominators.

Enhancements:
- Update mkpatch read/write wrappers to honor coverage blacklists while still performing the underlying IIO operations.
- Extend the pytest plugin to extract blacklist specs from hardware maps and pass them into the coverage tracker at session start.
- Document blacklist configuration and semantics in the CLI documentation, including glob matching and limitations for debug attributes.

Tests:
- Add unit tests for blacklist matching, context map exclusion behavior, per-hardware blacklist propagation, mkpatch increment gating, and blacklist extraction from hardware maps.
- Add an emulation-based end-to-end test verifying that blacklisted entries are absent from generated coverage JSON while non-blacklisted siblings remain.