### PR TITLE
test: cover extract_blacklists non-list branch (restore coverage)

### DIFF
--- a/tests/test_plugin_unit.py
+++ b/tests/test_plugin_unit.py
@@ -134,6 +134,8 @@ def test_extract_blacklists():
             {"blacklist": {"devices": ["xadc"]}},
         ],
         "fmcomms2": ["ad9361-phy"],
+        # A malformed entry whose value is not a list is skipped defensively.
+        "weird": None,
     }
     assert plugin.extract_blacklists(hw_map) == {"pluto": {"devices": ["xadc"]}}
 


### PR DESCRIPTION
## Summary

Follow-up to #70. Coveralls flagged a 0.01% coverage decrease on `main` after #70.

Root cause: pytest-cov cannot credit `pytest_libiio`'s import-time `def`/`class` lines (the plugin is imported at pytest startup, before coverage begins), so the newly-added — and fully runtime-tested — `Blacklist` class's structural lines counted against the total. The one genuinely-uncovered *runtime* line introduced by #70 was the defensive `if not isinstance(items, list): continue` branch in `extract_blacklists`.

This adds a malformed (non-list) hardware-map entry to the existing `test_extract_blacklists`, exercising that branch and restoring coverage.

Note: the Coveralls status is not a required check and `main` is not branch-protected, so this was non-blocking — but covering the branch is the correct, low-risk fix.

https://claude.ai/code/session_01XmLzEBjfG32VnfgUswwxSP

## Summary by Sourcery

Tests:
- Extend extract_blacklists unit test with a malformed non-list hardware-map entry to exercise the defensive skip branch.